### PR TITLE
fix date select not correctly checking if time range should be relative

### DIFF
--- a/projects/squac-ui/src/app/shared/components/date-select/date-select.component.ts
+++ b/projects/squac-ui/src/app/shared/components/date-select/date-select.component.ts
@@ -193,7 +193,7 @@ export class DateSelectComponent implements OnInit, OnChanges {
         );
         // if the diff matches a timerange, check if the
         // startDate is "close enough" to now
-        if (timeRange && endCopy.diff(this.startDate, "minute") < 1) {
+        if (timeRange && endCopy.diff(Date.now(), "day") > -1) {
           this.datesUpdated(null, null, true, diff, timeRange);
         } else {
           // no time range found, use start and end times


### PR DESCRIPTION
Fix daterange selector using a relative time range instead of fixed for past dates. 