### PR TITLE
Fix date select timezone

### DIFF
--- a/projects/squac-ui/src/app/features/dashboard/components/widget-edit-options/widget-edit-options.component.ts
+++ b/projects/squac-ui/src/app/features/dashboard/components/widget-edit-options/widget-edit-options.component.ts
@@ -64,7 +64,8 @@ import { OptionForm, OptionsForm, ThresholdForm } from "./interfaces";
   ],
 })
 export class WidgetEditOptionsComponent
-  implements OnChanges, OnDestroy, OnInit {
+  implements OnChanges, OnDestroy, OnInit
+{
   subscriptions: Subscription = new Subscription();
   @Input() selectedMetrics: Metric[];
   @Input() type: WidgetType;

--- a/projects/squac-ui/src/app/shared/components/date-select/date-select.component.ts
+++ b/projects/squac-ui/src/app/shared/components/date-select/date-select.component.ts
@@ -229,7 +229,6 @@ export class DateSelectComponent implements OnInit, OnChanges {
           endDate !== this.initialEndDate)) ||
       (!startDate && !endDate && rangeInSeconds !== this.secondsAgoFromNow)
     ) {
-      console.log(startDate, endDate)
       this.datesChanged.emit({
         startDate,
         endDate,

--- a/projects/squac-ui/src/app/shared/components/date-select/date-select.component.ts
+++ b/projects/squac-ui/src/app/shared/components/date-select/date-select.component.ts
@@ -64,9 +64,9 @@ export class DateSelectComponent implements OnInit, OnChanges {
 
   selected:
     | {
-        startDate: dayjs.Dayjs;
-        endDate: dayjs.Dayjs;
-      }
+      startDate: dayjs.Dayjs;
+      endDate: dayjs.Dayjs;
+    }
     | undefined;
   selectedRange: any;
   rangesForDatePicker: Record<string, [dayjs.Dayjs, dayjs.Dayjs]> = {};
@@ -177,7 +177,7 @@ export class DateSelectComponent implements OnInit, OnChanges {
         .startOf("minute")
         .clone();
 
-      if (startCopy.isUTC()) {
+      if (!startCopy.isUTC()) {
         // datepicker uses local time, but we want users to think
         // its UTC, so values need to be adjusted to UTC
         startCopy = this.dateService.addUtcOffset(startCopy);
@@ -229,6 +229,7 @@ export class DateSelectComponent implements OnInit, OnChanges {
           endDate !== this.initialEndDate)) ||
       (!startDate && !endDate && rangeInSeconds !== this.secondsAgoFromNow)
     ) {
+      console.log(startDate, endDate)
       this.datesChanged.emit({
         startDate,
         endDate,

--- a/projects/squac-ui/src/app/shared/components/date-select/date-select.component.ts
+++ b/projects/squac-ui/src/app/shared/components/date-select/date-select.component.ts
@@ -64,9 +64,9 @@ export class DateSelectComponent implements OnInit, OnChanges {
 
   selected:
     | {
-      startDate: dayjs.Dayjs;
-      endDate: dayjs.Dayjs;
-    }
+        startDate: dayjs.Dayjs;
+        endDate: dayjs.Dayjs;
+      }
     | undefined;
   selectedRange: any;
   rangesForDatePicker: Record<string, [dayjs.Dayjs, dayjs.Dayjs]> = {};

--- a/projects/widgets/src/lib/services/widget-config.service.ts
+++ b/projects/widgets/src/lib/services/widget-config.service.ts
@@ -533,7 +533,8 @@ export class WidgetConfigService {
       if (param.value) {
         const name = param.name ? param.name : param.seriesName;
         str += `
-          <tr><td> ${param.marker
+          <tr><td> ${
+            param.marker
           } ${name} </td><td> ${param.value[2]?.toPrecision(4)}</td></tr>`;
       }
     });

--- a/projects/widgets/src/lib/widget-types/timechart/config.ts
+++ b/projects/widgets/src/lib/widget-types/timechart/config.ts
@@ -19,11 +19,13 @@ export const TIMECHART_CONFIG: WidgetTypeInfo = {
     defaultDisplay: "channel",
     displayOptions: {
       channel: {
-        description: "each line is a channel - values are raw measurement values",
+        description:
+          "each line is a channel - values are raw measurement values",
         dimensions: ["y-axis"],
       },
       scatter: {
-        description: "dots are shown instead of lines - values are raw measurement values",
+        description:
+          "dots are shown instead of lines - values are raw measurement values",
         dimensions: ["y-axis"],
       },
     },

--- a/projects/widgets/src/lib/widget-types/timechart/timechart.component.ts
+++ b/projects/widgets/src/lib/widget-types/timechart/timechart.component.ts
@@ -33,7 +33,8 @@ import { NgxEchartsModule, NGX_ECHARTS_CONFIG } from "ngx-echarts";
 })
 export class TimechartComponent
   extends EChartComponent
-  implements OnInit, WidgetTypeComponent, OnDestroy {
+  implements OnInit, WidgetTypeComponent, OnDestroy
+{
   /** max # of measurement widths before chart should disconnect */
   maxMeasurementGap = 1.5;
 


### PR DESCRIPTION
Change datepicker conversion of local to UTC to happen when the date is not UTC, instead of when it already is UTC.

No idea how this bug lasted for this long, which is making me question everything.

Fixes #452 